### PR TITLE
XLDO-37 & XLDO-38 Improvements for XL JetPack Docker Image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[]
+image::applejack.png[600,500]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[600,500]
+image::applejack.png[800,400]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[applejack,200,200,float="right",align="center"]
+image::applejack.png[applejack,400,400,align="center"]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[applejack,400,400,align="center"]
+image::applejack.png[]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,14 @@ If you want to generate the Dockerfiles for a specific components of the XebiaLa
 
 [source,shell,subs="verbatim,attributes"]
 ----
-$ {executable} render --xl-version <version> --product {xl-deploy,xl-release}
+$ {executable} render --xl-version <version> --product xl-deploy --product xl-release
+----
+
+If you want to specify different base image organisation than default one "xebialabs" in which generated docker images will pull from you can use `--pull-registry`, This may be needed while generating Docker images for XL Jetpack Release and xl JetPack Deploy from xebialabsunsupported organisation.
+
+[source,shell,subs="verbatim,attributes"]
+----
+$ {executable} render --xl-version <version> --product xl-jetpack-deploy --pull-registry xebialabsunsupported
 ----
 
 If you want to generate an updated set of Dockerfiles for an already released version of the XebiaLabs DevOps Platform, the following command will generate a version tag of `<version>-<suffix>`:
@@ -83,10 +90,19 @@ If you only want to build a Docker image for a specific target operating system,
 
 [source,shell,subs="verbatim,attributes"]
 ----
-$ {executable} build --xl-version <version> --target-os {rhel,centos,debian-slim}
+$ {executable} build --xl-version <version> --target-os rhel --target-os centos --target-os debian-slim
+----
+Note: For rhel images you will need to build it in RedHat OS with valid RHEL subscription.
+
+If you want to push Docker image while building you need to use `--push` and `--registry` with dockerhub organisation you need to push to which is by default xebialabs, see following command:
+
+[source,shell,subs="verbatim,attributes"]
+----
+$ {executable} build --xl-version <version> --target-os centos --push --registry xebialabs
 ----
 
 === Building an image for an alpha version of XL Deploy or XL Release
+Alpha versions are not released to Distribution site hence you will need to get those versions from nexus by specifying `--download-source`, see the following command:
 [source,shell,subs="verbatim,attributes"]
 ----
 $ {executable} build --xl-version <version> --download-username <LDAP username> --download-source nexus
@@ -96,5 +112,5 @@ If you also want to push it to the xebialabsunsupported organisation, use the fo
 
 [source,shell,subs="verbatim,attributes"]
 ----
-$ {executable} build --xl-version <version> --download-username <LDAP username> --download-source nexus --registry xebialabsunsupported
+$ {executable} build --xl-version <version> --download-username <LDAP username> --download-source nexus --push --registry xebialabsunsupported
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -50,11 +50,11 @@ If you want to generate the Dockerfiles for a specific components of the XebiaLa
 $ {executable} render --xl-version <version> --product xl-deploy --product xl-release
 ----
 
-If you want to specify different base image organisation than default one "xebialabs" in which generated docker images will pull from you can use `--pull-registry`, This may be needed while generating Docker images for XL Jetpack Release and xl JetPack Deploy from xebialabsunsupported organisation.
+If you want to specify different base image organisation than default one "xebialabs" in which generated docker images will pull from you can use `--registry`, This may be needed while generating Docker images for XL Jetpack Release and xl JetPack Deploy from xebialabsunsupported organisation.
 
 [source,shell,subs="verbatim,attributes"]
 ----
-$ {executable} render --xl-version <version> --product xl-jetpack-deploy --pull-registry xebialabsunsupported
+$ {executable} render --xl-version <version> --product xl-jetpack-deploy --registry xebialabsunsupported
 ----
 
 If you want to generate an updated set of Dockerfiles for an already released version of the XebiaLabs DevOps Platform, the following command will generate a version tag of `<version>-<suffix>`:

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[800,400]
+image::applejack.png[500,400,align="center"]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ Author: XebiaLabs Development Team
 :source-highligher: pygments
 
 == Meet Applejack
-image::applejack.png[500,400,align="center"]
+image::applejack.png[applejack,200,200,float="right",align="center"]
 Applejack loves to help you generate Dockerfiles for the XebiaLabs DevOps Platform. She is also able to commit them to version control or create the Docker images from whatever she generates. You just have to feed her a Python environment.
 
 == Prerequisites

--- a/applejack.py
+++ b/applejack.py
@@ -42,6 +42,7 @@ def applejack():
 @applejack.command(help="Render the templates")
 @shared_opts
 @click.option('--commit', '-c', is_flag=True, help="Commit and tag the generated Dockerfiles.")
+@click.option('--pull-registry', help="Registry to pull XebiaLabs base Docker image from.", default='xebialabs')
 def render(**kwargs):
     renderer = Renderer(kwargs)
     for product in (kwargs['product'] or all_product_configs()):

--- a/applejack.py
+++ b/applejack.py
@@ -23,6 +23,7 @@ class ProductConfigType(click.Choice):
 _shared_opts = [
     click.option('--product', multiple=True, help="The product to build the files / images for.", type=ProductConfigType(all_products())),
     click.option('--xl-version', help="Product version, e.g. 8.1.0", required=True),
+    click.option('--registry', help="Docker Registry to use.", default='xebialabs'),
     click.option('--suffix', help="The (optional) suffix attached to the Docker and Git commit tags. Only used when a new version of the Docker images is released for the same product version"),
 ]
 
@@ -42,7 +43,6 @@ def applejack():
 @applejack.command(help="Render the templates")
 @shared_opts
 @click.option('--commit', '-c', is_flag=True, help="Commit and tag the generated Dockerfiles.")
-@click.option('--registry', help="Registry to pull XebiaLabs base Docker image from.", default='xebialabs')
 def render(**kwargs):
     renderer = Renderer(kwargs)
     for product in (kwargs['product'] or all_product_configs()):
@@ -61,7 +61,6 @@ def render(**kwargs):
 @click.option('--download-username', help="Username to use to download product ZIP.")
 @click.option('--download-password', help="Password to use to download product ZIP.")
 @click.option('--target-os', multiple=True, help="The target container OS to build and/or push.")
-@click.option('--registry', help="Registry to push the Docker image to.", default='xebialabs')
 @click.option('--use-cache', is_flag=True, help="Don't download product ZIP if already downloaded, don't pull the base image and use the Docker build cache")
 def build(**kwargs):
     for product_conf in (kwargs['product'] or all_product_configs()):

--- a/applejack.py
+++ b/applejack.py
@@ -23,7 +23,7 @@ class ProductConfigType(click.Choice):
 _shared_opts = [
     click.option('--product', multiple=True, help="The product to build the files / images for.", type=ProductConfigType(all_products())),
     click.option('--xl-version', help="Product version, e.g. 8.1.0", required=True),
-    click.option('--registry', help="Docker Registry to use.", default='xebialabs'),
+    click.option('--registry', help="Docker registry to use, either to pull from when used with render or to push to when used with build", default='xebialabs'),
     click.option('--suffix', help="The (optional) suffix attached to the Docker and Git commit tags. Only used when a new version of the Docker images is released for the same product version"),
 ]
 

--- a/applejack.py
+++ b/applejack.py
@@ -42,7 +42,7 @@ def applejack():
 @applejack.command(help="Render the templates")
 @shared_opts
 @click.option('--commit', '-c', is_flag=True, help="Commit and tag the generated Dockerfiles.")
-@click.option('--pull-registry', help="Registry to pull XebiaLabs base Docker image from.", default='xebialabs')
+@click.option('--registry', help="Registry to pull XebiaLabs base Docker image from.", default='xebialabs')
 def render(**kwargs):
     renderer = Renderer(kwargs)
     for product in (kwargs['product'] or all_product_configs()):

--- a/applejack/__init__.py
+++ b/applejack/__init__.py
@@ -49,7 +49,7 @@ def image_version(version, suffix):
     return version if not suffix else "%s-%s" % (version, suffix)
 
 def registry(registry):
-    """Return the pull registry from the --registry passed in."""
+    """Return registry from the --registry passed in."""
     return registry
 
 

--- a/applejack/__init__.py
+++ b/applejack/__init__.py
@@ -48,6 +48,10 @@ def image_version(version, suffix):
     """Return the image version from the version and suffix passed in."""
     return version if not suffix else "%s-%s" % (version, suffix)
 
+def pull_registry(pull_registry):
+    """Return the pull registry from the pull-registry passed in."""
+    return pull_registry
+
 
 def major_minor(image_version):
     """Split a version into its 2 root components (major, minor)."""

--- a/applejack/__init__.py
+++ b/applejack/__init__.py
@@ -48,9 +48,9 @@ def image_version(version, suffix):
     """Return the image version from the version and suffix passed in."""
     return version if not suffix else "%s-%s" % (version, suffix)
 
-def pull_registry(pull_registry):
-    """Return the pull registry from the pull-registry passed in."""
-    return pull_registry
+def registry(registry):
+    """Return the pull registry from the --registry passed in."""
+    return registry
 
 
 def major_minor(image_version):

--- a/applejack/conf/products/xl-jetpack-deploy.yml
+++ b/applejack/conf/products/xl-jetpack-deploy.yml
@@ -3,10 +3,12 @@ dockerfiles:
   default: 'debian-slim'
   os:
     debian-slim: debian-slim/xljetpack_deploy_Dockerfile.j2
+    centos: centos/xljetpack_deploy_Dockerfile.j2
 resources:
   dirs:
     - xl-jetpack
 context:
+  base_product: xl-deploy
   product: xl-jetpack-deploy
   product_name: XL Jetpack Deploy
   product_description: Automate, orchestrate and get visibility into your release pipelines at Enterprise-scale.

--- a/applejack/conf/products/xl-jetpack-release.yml
+++ b/applejack/conf/products/xl-jetpack-release.yml
@@ -3,10 +3,12 @@ dockerfiles:
   default: 'debian-slim'
   os:
     debian-slim: debian-slim/xljetpack_release_Dockerfile.j2
+    centos: centos/xljetpack_release_Dockerfile.j2
 resources:
   dirs:
     - xl-jetpack
 context:
+  base_product: xl-release
   product: xl-jetpack-release
   product_name: XL Jetpack Release
   product_description: Enterprise-scale Application Release Automation for any environment.

--- a/applejack/renderer.py
+++ b/applejack/renderer.py
@@ -9,7 +9,7 @@ class Renderer(object):
     def __init__(self, commandline_args):
         """Initialize the XebiaLabs Dockerfile template rendering engine."""
         self.commit = commandline_args['commit']
-        self.pull_registry = commandline_args['pull_registry']
+        self.registry = commandline_args['registry']
         self.version = commandline_args['xl_version']
         self.image_version = image_version(commandline_args['xl_version'], commandline_args['suffix'])
 
@@ -36,7 +36,7 @@ class Renderer(object):
         context = dict(product_conf['context'])
         context['image_version'] = self.image_version
         context['xl_version'] = self.version
-        context['pull_registry'] = self.pull_registry
+        context['registry'] = self.registry
         context['today'] = datetime.now().strftime('%Y-%m-%d')
         return context
 

--- a/applejack/renderer.py
+++ b/applejack/renderer.py
@@ -9,6 +9,7 @@ class Renderer(object):
     def __init__(self, commandline_args):
         """Initialize the XebiaLabs Dockerfile template rendering engine."""
         self.commit = commandline_args['commit']
+        self.pull_registry = commandline_args['pull_registry']
         self.version = commandline_args['xl_version']
         self.image_version = image_version(commandline_args['xl_version'], commandline_args['suffix'])
 
@@ -35,6 +36,7 @@ class Renderer(object):
         context = dict(product_conf['context'])
         context['image_version'] = self.image_version
         context['xl_version'] = self.version
+        context['pull_registry'] = self.pull_registry
         context['today'] = datetime.now().strftime('%Y-%m-%d')
         return context
 

--- a/templates/dockerfiles/centos/xljetpack_deploy_Dockerfile.j2
+++ b/templates/dockerfiles/centos/xljetpack_deploy_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:8.5.2-debian-slim
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-centos
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/centos/xljetpack_deploy_Dockerfile.j2
+++ b/templates/dockerfiles/centos/xljetpack_deploy_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-centos
+FROM {{ registry }}/{{ base_product }}:{{ xl_version }}-centos
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/centos/xljetpack_release_Dockerfile.j2
+++ b/templates/dockerfiles/centos/xljetpack_release_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-centos
+FROM {{ registry }}/{{ base_product }}:{{ xl_version }}-centos
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/centos/xljetpack_release_Dockerfile.j2
+++ b/templates/dockerfiles/centos/xljetpack_release_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:8.5.2-debian-slim
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-centos
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:{{ xl_version }}
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-debian-slim
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}
+FROM {{ registry }}/{{ base_product }}:{{ xl_version }}
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_deploy_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-debian-slim
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:{{ xl_version }}
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-debian-slim
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}
+FROM {{ registry }}/{{ base_product }}:{{ xl_version }}
 
 # Don't run as root
 USER xebialabs

--- a/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
+++ b/templates/dockerfiles/debian-slim/xljetpack_release_Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}-debian-slim
+FROM {{ pull_registry }}/{{ base_product }}:{{ xl_version }}
 
 # Don't run as root
 USER xebialabs

--- a/xl-deploy/8.5/centos/Dockerfile
+++ b/xl-deploy/8.5/centos/Dockerfile
@@ -7,10 +7,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-deploy-server
 
 # Install XL Deploy
-COPY resources/xl-deploy-8.5.2-server.zip /tmp
+COPY resources/xl-deploy-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-deploy-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-deploy-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-deploy-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-deploy-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -60,7 +60,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-deploy" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Deploy" \
       description="Enterprise-scale Application Release Automation for any environment" \

--- a/xl-deploy/8.5/debian-slim/Dockerfile
+++ b/xl-deploy/8.5/debian-slim/Dockerfile
@@ -7,10 +7,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-deploy-server
 
 # Install XL Deploy
-COPY resources/xl-deploy-8.5.2-server.zip /tmp
+COPY resources/xl-deploy-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-deploy-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-deploy-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-deploy-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-deploy-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -60,7 +60,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-deploy" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Deploy" \
       description="Enterprise-scale Application Release Automation for any environment" \

--- a/xl-deploy/8.5/resources/help.md
+++ b/xl-deploy/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-DEPLOY (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-25
+% 2019-02-26
 
 # NAME
 xl-deploy \- Enterprise-scale Application Release Automation for any environment

--- a/xl-deploy/8.5/resources/help.md
+++ b/xl-deploy/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-DEPLOY (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-22
+% 2019-02-24
 
 # NAME
 xl-deploy \- Enterprise-scale Application Release Automation for any environment

--- a/xl-deploy/8.5/resources/help.md
+++ b/xl-deploy/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-DEPLOY (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-24
+% 2019-02-25
 
 # NAME
 xl-deploy \- Enterprise-scale Application Release Automation for any environment

--- a/xl-deploy/8.5/rhel/Dockerfile
+++ b/xl-deploy/8.5/rhel/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-deploy" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Deploy" \
       description="Enterprise-scale Application Release Automation for any environment" \
@@ -37,10 +37,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-deploy-server
 
 # Install XL Deploy
-COPY resources/xl-deploy-8.5.2-server.zip /tmp
+COPY resources/xl-deploy-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-deploy-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-deploy-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-deploy-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-deploy-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/

--- a/xl-jetpack-deploy/8.5/centos/Dockerfile
+++ b/xl-jetpack-deploy/8.5/centos/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:8.5.2-centos
+FROM xebialabs/xl-deploy:8.5.3-centos
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-deploy/8.5/centos/Dockerfile
+++ b/xl-jetpack-deploy/8.5/centos/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:8.5.2-debian-slim
+FROM xebialabs/xl-deploy:8.5.2-centos
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-deploy/8.5/debian-slim/Dockerfile
+++ b/xl-jetpack-deploy/8.5/debian-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:8.5.2
+FROM xebialabs/xl-deploy:8.5.3
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-deploy/8.5/debian-slim/Dockerfile
+++ b/xl-jetpack-deploy/8.5/debian-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-deploy:8.5.2-debian-slim
+FROM xebialabs/xl-deploy:8.5.2
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-release/8.5/centos/Dockerfile
+++ b/xl-jetpack-release/8.5/centos/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:8.5.2-debian-slim
+FROM xebialabs/xl-release:8.5.2-centos
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-release/8.5/centos/Dockerfile
+++ b/xl-jetpack-release/8.5/centos/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:8.5.2-centos
+FROM xebialabs/xl-release:8.5.3-centos
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-release/8.5/debian-slim/Dockerfile
+++ b/xl-jetpack-release/8.5/debian-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:8.5.2
+FROM xebialabs/xl-release:8.5.3
 
 # Don't run as root
 USER xebialabs

--- a/xl-jetpack-release/8.5/debian-slim/Dockerfile
+++ b/xl-jetpack-release/8.5/debian-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:8.5.2-debian-slim
+FROM xebialabs/xl-release:8.5.2
 
 # Don't run as root
 USER xebialabs

--- a/xl-release/8.5/centos/Dockerfile
+++ b/xl-release/8.5/centos/Dockerfile
@@ -7,10 +7,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-release-server
 
 # Install XL Deploy
-COPY resources/xl-release-8.5.2-server.zip /tmp
+COPY resources/xl-release-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-release-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-release-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-release-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-release-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -60,7 +60,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-release" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Release" \
       description="Enterprise-scale Application Release Automation for any environment" \

--- a/xl-release/8.5/debian-slim/Dockerfile
+++ b/xl-release/8.5/debian-slim/Dockerfile
@@ -7,10 +7,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-release-server
 
 # Install XL Deploy
-COPY resources/xl-release-8.5.2-server.zip /tmp
+COPY resources/xl-release-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-release-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-release-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-release-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-release-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -60,7 +60,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-release" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Release" \
       description="Enterprise-scale Application Release Automation for any environment" \

--- a/xl-release/8.5/resources/help.md
+++ b/xl-release/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-RELEASE (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-24
+% 2019-02-25
 
 # NAME
 xl-release \- Automate, orchestrate and get visibility into your release pipelines — at enterprise scale

--- a/xl-release/8.5/resources/help.md
+++ b/xl-release/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-RELEASE (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-22
+% 2019-02-24
 
 # NAME
 xl-release \- Automate, orchestrate and get visibility into your release pipelines — at enterprise scale

--- a/xl-release/8.5/resources/help.md
+++ b/xl-release/8.5/resources/help.md
@@ -1,6 +1,6 @@
 % XL-RELEASE (1) Container Image Pages
 % XebiaLabs Development Team
-% 2019-02-25
+% 2019-02-26
 
 # NAME
 xl-release \- Automate, orchestrate and get visibility into your release pipelines — at enterprise scale

--- a/xl-release/8.5/rhel/Dockerfile
+++ b/xl-release/8.5/rhel/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 LABEL name="xebialabs/xl-release" \
       maintainer="docker@xebialabs.com" \
       vendor="XebiaLabs" \
-      version="8.5.2" \
+      version="8.5.3" \
       release="1" \
       summary="XL Release" \
       description="Enterprise-scale Application Release Automation for any environment" \
@@ -37,10 +37,10 @@ ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
 ENV APP_HOME=${APP_ROOT}/xl-release-server
 
 # Install XL Deploy
-COPY resources/xl-release-8.5.2-server.zip /tmp
+COPY resources/xl-release-8.5.3-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
-    unzip /tmp/xl-release-8.5.2-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/xl-release-8.5.2-server ${APP_HOME}
+    unzip /tmp/xl-release-8.5.3-server.zip -d ${APP_ROOT} && \
+    mv ${APP_ROOT}/xl-release-8.5.3-server ${APP_HOME}
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/


### PR DESCRIPTION
- Added new flag "--pull-registry" for rendering to specify Registry to pull XebiaLabs base Docker image from by default it will use xebialabs.
- This is needed for generating XLJetPack images especially during nightly as alpha versions are not pushed to official docker hub registry xebialabs hence we need a way to specify different registry like xebialabsunsupported etc.
- Added new context for XLJetpack conf to use "base_product" which is passed to docker file template.
- Added support for generating Image for CentOS.
- Added more details in Readme file including new flag added and xl jetpack images.
- Tested those changes locally without issues.