### PR TITLE
LOVE-779 do not exit container for db2, oracle jdbc drivers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -128,3 +128,9 @@ To connect with these databases both the products needs jdbc driver in the class
 By default with these official images we provide jdbc drivers for mysql, mssql and postgresql.
 
 if you have a requirement to connect to the db2, oracle then you will need to provide jdbc drivers by creating your custom docker image on top of official image and copying jdbc drivers in the `lib` directory.
+
+Example : Adding db2 jdbc driver in classpath of xl-release container
+
+[source,shell,subs="verbatim,attributes"]
+FROM xebialabs/xl-release:8.5
+ADD db2jcc4-10.1.jar /opt/xebialabs/xl-release-server/lib

--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,6 @@ XL-Deploy : https://docs.xebialabs.com/xl-deploy/how-to/configure-the-xl-deploy-
 
 To connect with these databases both the products needs jdbc driver in the classpath, example:  inside `/opt/xebialabs/xl-release-server/lib` (for xl release).
 
-By default with thee official images we provide jdbc drivers for mysql, mssql and postgresql.
+By default with these official images we provide jdbc drivers for mysql, mssql and postgresql.
 
 if you have a requirement to connect to the db2, oracle then you will need to provide jdbc drivers by creating your custom docker image on top of official image and copying jdbc drivers in the `lib` directory.

--- a/README.adoc
+++ b/README.adoc
@@ -114,3 +114,17 @@ If you also want to push it to the xebialabsunsupported organisation, use the fo
 ----
 $ {executable} build --xl-version <version> --download-username <LDAP username> --download-source nexus --push --registry xebialabsunsupported
 ----
+
+=== Database driver support
+
+Both XL Release and XL Deploy supports db2, mysql, mssql, postgresql, oracle database for production setups more information can be found on official documentation :
+
+XL-Release : https://docs.xebialabs.com/xl-release/how-to/configure-the-xl-release-sql-repository-in-a-database.html
+
+XL-Deploy : https://docs.xebialabs.com/xl-deploy/how-to/configure-the-xl-deploy-sql-repository.html
+
+To connect with these databases both the products needs jdbc driver in the classpath, example:  inside `/opt/xebialabs/xl-release-server/lib` (for xl release).
+
+By default with thee official images we provide jdbc drivers for mysql, mssql and postgresql.
+
+if you have a requirement to connect to the db2, oracle then you will need to provide jdbc drivers by creating your custom docker image on top of official image and copying jdbc drivers in the `lib` directory.

--- a/templates/resources/common/bin/run-in-container.sh.j2
+++ b/templates/resources/common/bin/run-in-container.sh.j2
@@ -21,8 +21,7 @@ function copy_db_driver {
       ;;
     jdbc:oracle:*)
       XL_DB_DRIVER="oracle.jdbc.OracleDriver"
-      echo "Still need support for 'oracle' jdbc driver"
-      exit 1
+      echo "oracle jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     jdbc:mysql:*)
       XL_DB_DRIVER="com.mysql.jdbc.Driver"
@@ -38,8 +37,7 @@ function copy_db_driver {
       ;;
     jdbc:db2:*)
       XL_DB_DRIVER="com.ibm.db2.jcc.DB2Driver"
-      echo "Still need support for 'db2' jdbc driver"
-      exit 1
+      echo "db2 jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     *)
         echo "Database type could not be inferred from url '${XL_REPO_DB_URL}', supported db types are 'h2', 'oracle', 'mysql', 'postgresql', 'sqlserver', 'db2'"

--- a/xl-deploy/8.5/resources/bin/run-in-container.sh
+++ b/xl-deploy/8.5/resources/bin/run-in-container.sh
@@ -19,8 +19,7 @@ function copy_db_driver {
       ;;
     jdbc:oracle:*)
       XL_DB_DRIVER="oracle.jdbc.OracleDriver"
-      echo "Still need support for 'oracle' jdbc driver"
-      exit 1
+      echo "oracle jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     jdbc:mysql:*)
       XL_DB_DRIVER="com.mysql.jdbc.Driver"
@@ -36,8 +35,7 @@ function copy_db_driver {
       ;;
     jdbc:db2:*)
       XL_DB_DRIVER="com.ibm.db2.jcc.DB2Driver"
-      echo "Still need support for 'db2' jdbc driver"
-      exit 1
+      echo "db2 jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     *)
         echo "Database type could not be inferred from url '${XL_REPO_DB_URL}', supported db types are 'h2', 'oracle', 'mysql', 'postgresql', 'sqlserver', 'db2'"

--- a/xl-release/8.5/resources/bin/run-in-container.sh
+++ b/xl-release/8.5/resources/bin/run-in-container.sh
@@ -19,8 +19,7 @@ function copy_db_driver {
       ;;
     jdbc:oracle:*)
       XL_DB_DRIVER="oracle.jdbc.OracleDriver"
-      echo "Still need support for 'oracle' jdbc driver"
-      exit 1
+      echo "oracle jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     jdbc:mysql:*)
       XL_DB_DRIVER="com.mysql.jdbc.Driver"
@@ -36,8 +35,7 @@ function copy_db_driver {
       ;;
     jdbc:db2:*)
       XL_DB_DRIVER="com.ibm.db2.jcc.DB2Driver"
-      echo "Still need support for 'db2' jdbc driver"
-      exit 1
+      echo "db2 jdbc driver is not provided by default in the classpath, please make sure you provide one. Please refer readme for more details"
       ;;
     *)
         echo "Database type could not be inferred from url '${XL_REPO_DB_URL}', supported db types are 'h2', 'oracle', 'mysql', 'postgresql', 'sqlserver', 'db2'"


### PR DESCRIPTION
- [ ] It should be possible to provide db2/ ojdbc driver in custom image, currently it fails since container exits when it tries to run the base image. 
- [ ] readme is updated with more infor for end user