### PR TITLE
ENG-1764 -Resolve YAMLLoadWarning while calling yaml.load() 

### DIFF
--- a/applejack/__init__.py
+++ b/applejack/__init__.py
@@ -16,7 +16,7 @@ def load_product_config(product):
     p = Path("applejack/conf/products") / ("%s.yml" % product)
     if not p.exists():
         raise Exception("Could not find configuration for product %s in %s" % (product, p))
-    return yaml.load(p.read_text())
+    return yaml.load(p.read_text(), yaml.FullLoader)
 
 
 def all_products():


### PR DESCRIPTION

**Issue:**  YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

**Fix**: Added FullLoader to overcome this warning.

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

