### PR TITLE
Remove the nested RUN Instructions

### DIFF
--- a/templates/dockerfiles/xl-cli/Dockerfile.j2
+++ b/templates/dockerfiles/xl-cli/Dockerfile.j2
@@ -7,7 +7,7 @@ COPY resources/{{ product }}-{{ xl_version }}-linux-amd64.bin /tmp
 
 RUN mkdir -p ${APP_HOME} && \
     mv /tmp/{{ product }}-{{ xl_version }}-linux-amd64.bin ${APP_HOME}/xl && \
-    RUN chgrp -R 0 ${APP_ROOT} && \
+    chgrp -R 0 ${APP_ROOT} && \
     chmod -R g=u ${APP_ROOT} && \
     chmod g+x ${APP_HOME}/xl
 


### PR DESCRIPTION
Description:


Story: https://digitalai.atlassian.net/browse/ENG-4616
Due to Nested RUN Instructions not able to build docker image of xl-cli(xl-client).