### PR TITLE
ENG-8074 Add a startup flag that defines what's the primary source for plugins

### DIFF
--- a/applejack/conf/products/xl-deploy.yml
+++ b/applejack/conf/products/xl-deploy.yml
@@ -82,3 +82,5 @@ context:
     value: "false"
   - key: ENABLE_SATELLITE
     value: "false"
+  - key: PLUGIN_SOURCE
+    value: "database"

--- a/applejack/conf/products/xl-release.yml
+++ b/applejack/conf/products/xl-release.yml
@@ -72,3 +72,5 @@ context:
     value: "amqp://localhost:61616"
   - key: XLR_TASK_QUEUE_USERNAME
     value: "mqadmin"
+  - key: PLUGIN_SOURCE
+    value: "database"

--- a/templates/resources/common/bin/run-in-container.sh.j2
+++ b/templates/resources/common/bin/run-in-container.sh.j2
@@ -187,6 +187,12 @@ function check_force_upgrade {
      FORCE_UPGRADE_FLAG="-force-upgrades"
    fi
 }
+
+function set_plugin_source {
+    PLUGIN_SOURCE_FLAG="-plugin-source=${PLUGIN_SOURCE}"
+    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE}"
+}
+
 {% include 'includes/' + product + '-run-script.j2' %}
 
 {% if 'central-config' not in product %}
@@ -199,7 +205,8 @@ function check_force_upgrade {
 generate_product_conf
 generate_node_conf
 check_force_upgrade
+set_plugin_source
 
 # Start regular startup process
-exec ${APP_HOME}/bin/run.sh ${FORCE_UPGRADE_FLAG} "$@"
+exec ${APP_HOME}/bin/run.sh ${FORCE_UPGRADE_FLAG} ${PLUGIN_SOURCE_FLAG} "$@"
 

--- a/templates/resources/xl-release/default-conf/xl-release.conf.template.j2
+++ b/templates/resources/xl-release/default-conf/xl-release.conf.template.j2
@@ -46,11 +46,4 @@ xl {
   metrics {
     enabled = ${XL_METRICS_ENABLED}
   }
-
-  features {
-    plugins {
-      pluginSource="${PLUGIN_SOURCE}"
-    }
-  }
-
 }

--- a/templates/resources/xl-release/default-conf/xl-release.conf.template.j2
+++ b/templates/resources/xl-release/default-conf/xl-release.conf.template.j2
@@ -46,4 +46,11 @@ xl {
   metrics {
     enabled = ${XL_METRICS_ENABLED}
   }
+
+  features {
+    plugins {
+      pluginSource="${PLUGIN_SOURCE}"
+    }
+  }
+
 }


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/ENG-8074

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

