### PR TITLE
ENG-8074 Add a startup flag that defines what's the primary source for plugins

### DIFF
--- a/templates/resources/common/bin/run-in-container.sh.j2
+++ b/templates/resources/common/bin/run-in-container.sh.j2
@@ -196,7 +196,7 @@ function set_plugin_source {
         PLUGIN_SOURCE_FLAG="-plugin-source=${PLUGIN_SOURCE}"
     fi
 
-    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE}"
+    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE_FLAG}"
 }
 
 {% include 'includes/' + product + '-run-script.j2' %}

--- a/templates/resources/common/bin/run-in-container.sh.j2
+++ b/templates/resources/common/bin/run-in-container.sh.j2
@@ -208,5 +208,5 @@ check_force_upgrade
 set_plugin_source
 
 # Start regular startup process
-exec ${APP_HOME}/bin/run.sh ${FORCE_UPGRADE_FLAG} "$@"
+exec ${APP_HOME}/bin/run.sh ${FORCE_UPGRADE_FLAG} "$@" ${PLUGIN_SOURCE_FLAG}
 

--- a/templates/resources/common/bin/run-in-container.sh.j2
+++ b/templates/resources/common/bin/run-in-container.sh.j2
@@ -189,7 +189,13 @@ function check_force_upgrade {
 }
 
 function set_plugin_source {
-    PLUGIN_SOURCE_FLAG="-plugin-source=${PLUGIN_SOURCE}"
+    if [[ "$1" == "worker" ]]
+    then
+        PLUGIN_SOURCE_FLAG="-pluginSource=${PLUGIN_SOURCE}"
+    else
+        PLUGIN_SOURCE_FLAG="-plugin-source=${PLUGIN_SOURCE}"
+    fi
+
     echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE}"
 }
 
@@ -205,7 +211,7 @@ function set_plugin_source {
 generate_product_conf
 generate_node_conf
 check_force_upgrade
-set_plugin_source
+set_plugin_source $1
 
 # Start regular startup process
 exec ${APP_HOME}/bin/run.sh ${FORCE_UPGRADE_FLAG} "$@" ${PLUGIN_SOURCE_FLAG}

--- a/templates/resources/deploy-task-engine/bin/run-in-container.sh.j2
+++ b/templates/resources/deploy-task-engine/bin/run-in-container.sh.j2
@@ -112,6 +112,11 @@ function generate_product_conf {
     fi
 }
 
+function set_plugin_source {
+    PLUGIN_SOURCE_FLAG="-pluginSource=${PLUGIN_SOURCE}"
+    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE}"
+}
+
 {% include 'includes/' + product + '-run-script.j2' %}
 
 check_eula
@@ -121,4 +126,4 @@ store_license
 generate_product_conf
 
 # Start regular startup process
-exec ${APP_HOME}/bin/run.sh "$@"
+exec ${APP_HOME}/bin/run.sh "$@" ${PLUGIN_SOURCE_FLAG}

--- a/templates/resources/deploy-task-engine/bin/run-in-container.sh.j2
+++ b/templates/resources/deploy-task-engine/bin/run-in-container.sh.j2
@@ -114,7 +114,7 @@ function generate_product_conf {
 
 function set_plugin_source {
     PLUGIN_SOURCE_FLAG="-pluginSource=${PLUGIN_SOURCE}"
-    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE}"
+    echo "Configuring plugin source. Setting value to ${PLUGIN_SOURCE_FLAG}"
 }
 
 {% include 'includes/' + product + '-run-script.j2' %}
@@ -124,6 +124,7 @@ copy_db_driver
 copy_mq_driver
 store_license
 generate_product_conf
+set_plugin_source
 
 # Start regular startup process
 exec ${APP_HOME}/bin/run.sh "$@" ${PLUGIN_SOURCE_FLAG}


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/ENG-8074

The location of the PLUGIN_SOURCE_FLAG is not important in argument list, so I've put it to the last position.

Tested by building and running the whole cluster as described in the comment, all workers and masters start normally.

```
 ~/IdeaProjects/xl-docker-images/documentation/docs/manual/xl-deploy-ha   ENG-8074 ● ?  docker-compose -f docker-compose-xld-ha.yaml ps                                                                                                                                                               ✔  11:14:28 
             Name                            Command               State                                                            Ports                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
postgresql                        docker-entrypoint.sh postg ...   Up      0.0.0.0:5432->5432/tcp                                                                                                 
rabbitmq                          docker-entrypoint.sh rabbi ...   Up      15671/tcp, 0.0.0.0:15672->15672/tcp, 0.0.0.0:25672->25672/tcp, 0.0.0.0:4369->4369/tcp, 5671/tcp, 0.0.0.0:5672->5672/tcp
xl-deploy-ha_xl-deploy-master_1   /opt/xebialabs/tini -- /op ...   Up      4516/tcp                                                                                                               
xl-deploy-ha_xl-deploy-master_2   /opt/xebialabs/tini -- /op ...   Up      4516/tcp                                                                                                               
xl-deploy-lb                      /docker-entrypoint.sh hapr ...   Up      0.0.0.0:1936->1936/tcp, 0.0.0.0:8080->5000/tcp                                                                         
 ~/IdeaProjects/xl-docker-images/documentation/docs/manual/xl-deploy-ha   ENG-8074 ● ?  docker-compose -f docker-compose-xld-ha-workers.yaml ps                                                                                                                                                       ✔  11:14:54 
             Name                            Command               State    Ports  
-----------------------------------------------------------------------------------
xl-deploy-ha_xl-deploy-worker_1   /opt/xebialabs/tini -- /op ...   Up      4516/tcp
xl-deploy-ha_xl-deploy-worker_2   /opt/xebialabs/tini -- /op ...   Up      4516/tcp
 ~/IdeaProjects/xl-docker-images/documentation/docs/manual/xl-deploy-ha   ENG-8074 ● ?            
```

Also tested by running ./slim-up.sh and waited for everything to come up. It works.

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

