### PR TITLE
D-31846 disable pekko DnsClient warning in the worker logs

### DIFF
--- a/templates/resources/deploy-task-engine/default-conf/logback.xml
+++ b/templates/resources/deploy-task-engine/default-conf/logback.xml
@@ -37,6 +37,7 @@
     <logger name="org.springframework.beans.factory.support.DefaultListableBeanFactory" level="error"/>
     <logger name="liquibase" level="warn"/>
     <logger name="org.springframework.web.socket.adapter.jetty.JettyWebSocketHandlerAdapter" level="off"/>
+    <logger name="org.apache.pekko.io.dns.internal.DnsClient" level="error" />
 
     <!--  Audit logging -->
 


### PR DESCRIPTION
## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

