### PR TITLE
S-109339 Build product images for Redhat certification

### DIFF
--- a/applejack.py
+++ b/applejack.py
@@ -43,6 +43,7 @@ def applejack():
 @applejack.command(help="Render the templates")
 @shared_opts
 @click.option('--commit', '-c', is_flag=True, help="Commit and tag the generated Dockerfiles.")
+@click.option('--skip_vulnerable_libs', '-s', is_flag=True, help="Remove from the image vulnerable libraries.")
 def render(**kwargs):
     renderer = Renderer(kwargs)
     for product in (kwargs['product'] or all_product_configs()):

--- a/applejack/conf/products/central-configuration.yml
+++ b/applejack/conf/products/central-configuration.yml
@@ -6,6 +6,7 @@ dockerfiles:
     centos: centos/Dockerfile.j2
     amazonlinux: amazonlinux/Dockerfile.j2
     rhel: rhel/Dockerfile.j2
+    redhat: redhat/Dockerfile.j2
     ubuntu: ubuntu/Dockerfile.j2
 repositories:
   nexus: 'https://nexus.xebialabs.com/nexus/service/local/repositories/{repo}/content/ai/digital/config/central-configuration-server/{version}/{product}-server-{version}.zip'
@@ -22,9 +23,11 @@ context:
   license_server: https://download.xebialabs.com
   product: central-configuration
   product_name: Central configuration
+  product_info_url: https://digital.ai/products/deploy/
   product_description: Enterprise-scale Application Release Automation for any environment
   boot_conf: deployit.conf
   wrapper_conf: xlc-wrapper.conf.common
+  skip_vulnerable_libs: false
   central_config_files:
     - deploy-cluster.yaml
     - deploy-metrics.yaml

--- a/applejack/conf/products/deploy-task-engine.yml
+++ b/applejack/conf/products/deploy-task-engine.yml
@@ -3,6 +3,7 @@ dockerfiles:
   default: 'ubuntu'
   os:
     rhel: rhel/Dockerfile.j2
+    redhat: redhat/Dockerfile.j2
     debian-slim: debian-slim/Dockerfile.j2
     centos: centos/Dockerfile.j2
     amazonlinux: amazonlinux/Dockerfile.j2
@@ -21,10 +22,12 @@ context:
   license_server: https://download.xebialabs.com
   product: deploy-task-engine
   product_name: Deploy Worker
+  product_info_url: https://digital.ai/products/deploy/
   boot_conf: deployit.conf
   product_description: Enterprise-scale Application Release Automation for any environment
   license_file: deployit-license.lic
   wrapper_conf: xld-wrapper.conf.common
+  skip_vulnerable_libs: false
   port: 8180
   volumes:
     - "${APP_HOME}/conf"

--- a/applejack/conf/products/xl-deploy.yml
+++ b/applejack/conf/products/xl-deploy.yml
@@ -3,6 +3,7 @@ dockerfiles:
   default: 'ubuntu'
   os:
     rhel: rhel/Dockerfile.j2
+    redhat: redhat/Dockerfile.j2
     debian-slim: debian-slim/Dockerfile.j2
     centos: centos/Dockerfile.j2
     amazonlinux: amazonlinux/Dockerfile.j2
@@ -22,10 +23,12 @@ context:
   license_server: https://download.xebialabs.com
   product: xl-deploy
   product_name: XL Deploy
+  product_info_url: https://digital.ai/products/deploy/
   product_description: Enterprise-scale Application Release Automation for any environment
   license_file: deployit-license.lic
   boot_conf: deployit.conf
   wrapper_conf: xld-wrapper.conf.common
+  skip_vulnerable_libs: false
   conf_files:
     - xl-deploy.conf
   central_config_files:

--- a/applejack/conf/products/xl-release.yml
+++ b/applejack/conf/products/xl-release.yml
@@ -3,6 +3,7 @@ dockerfiles:
   default: 'ubuntu'
   os:
     rhel: rhel/Dockerfile.j2
+    redhat: redhat/Dockerfile.j2
     debian-slim: debian-slim/Dockerfile.j2
     centos: centos/Dockerfile.j2
     amazonlinux: amazonlinux/Dockerfile.j2
@@ -20,10 +21,12 @@ context:
   license_server: https://download.xebialabs.com
   product: xl-release
   product_name: XL Release
+  product_info_url: https://digital.ai/products/release/
   product_description: Automate, orchestrate and get visibility into your release pipelines — at enterprise scale
   license_file: xl-release-license.lic
   boot_conf: xl-release-server.conf
   wrapper_conf: xlr-wrapper-linux.conf
+  skip_vulnerable_libs: false
   conf_files:
   - xl-release.conf
   port: 5516

--- a/templates/dockerfiles/central-configuration/install.j2
+++ b/templates/dockerfiles/central-configuration/install.j2
@@ -39,11 +39,14 @@ RUN chmod +x /tmp/modify-wrapper-linux-conf.gawk && \
     mv /tmp/{{ wrapper_conf }} ${APP_HOME}/default-conf/{{ wrapper_conf }} && \
     rm /tmp/modify-wrapper-linux-conf.gawk
 
-
 # Set permissions
-RUN addgroup -S -g 10001 xebialabs
-RUN chgrp -R 10001 ${APP_ROOT} && \
+{%- if target_os == "redhat" %}
+RUN groupadd -r -g 10001 xebialabs && \
+{%- else %}
+RUN addgroup -S -g 10001 xebialabs && \
+{%- endif %}
+    chown -R 10001:10001 ${APP_ROOT} && \
     chmod -R g=u ${APP_ROOT} && \
+    chmod u+x ${APP_HOME}/bin/*.sh && \
     chmod g+x ${APP_HOME}/bin/*.sh && \
     chmod a+rwx ${APP_HOME}/centralConfiguration
-

--- a/templates/dockerfiles/deploy-task-engine/install.j2
+++ b/templates/dockerfiles/deploy-task-engine/install.j2
@@ -6,7 +6,11 @@
 COPY resources/{{ product }}-{{ xl_version }}.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
     unzip /tmp/{{ product }}-{{ xl_version }}.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/{{ product }}-{{ xl_version }} ${APP_HOME}
+    mv ${APP_ROOT}/{{ product }}-{{ xl_version }} ${APP_HOME} && \
+{% if skip_vulnerable_libs %}
+    rm ${APP_HOME}/lib/derby*.jar && \
+{% endif %}
+    true
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -40,13 +44,17 @@ RUN chmod +x /tmp/modify-wrapper-linux-conf.gawk && \
 
 # Move plugins directory to default-plugins, so that when no external plugins are loaded we can use the default
 RUN mv ${APP_HOME}/plugins ${APP_HOME}/default-plugins && \
-    mkdir ${APP_HOME}/plugins
-
-# Create empty 'repository', 'work', 'export', 'archive' and 'reports' directory
-RUN mkdir ${APP_HOME}/repository ${APP_HOME}/export ${APP_HOME}/archive ${APP_HOME}/work ${APP_HOME}/reports
+    mkdir ${APP_HOME}/plugins && \
+    # Create empty 'repository', 'work', 'export', 'archive' and 'reports' directory
+    mkdir ${APP_HOME}/repository ${APP_HOME}/export ${APP_HOME}/archive ${APP_HOME}/work ${APP_HOME}/reports
 
 # Set permissions
-RUN addgroup -S -g 10001 xebialabs
-RUN chgrp -R 10001 ${APP_ROOT} && \
+{%- if target_os == "redhat" %}
+RUN groupadd -r -g 10001 xebialabs && \
+{%- else %}
+RUN addgroup -S -g 10001 xebialabs && \
+{%- endif %}
+    chown -R 10001:10001 ${APP_ROOT} && \
     chmod -R g=u ${APP_ROOT} && \
+    chmod u+x ${APP_HOME}/bin/*.sh && \
     chmod g+x ${APP_HOME}/bin/*.sh

--- a/templates/dockerfiles/deploy-task-engine/variables.j2
+++ b/templates/dockerfiles/deploy-task-engine/variables.j2
@@ -1,3 +1,4 @@
 # Set root folders
-ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
-ENV APP_HOME=${APP_ROOT}/{{ product }}
+ENV USER_UID=10001 \ 
+    APP_ROOT=/opt/xebialabs \
+    APP_HOME=/opt/xebialabs/{{ product }}

--- a/templates/dockerfiles/install.j2
+++ b/templates/dockerfiles/install.j2
@@ -6,7 +6,12 @@
 COPY resources/{{ product }}-{{ xl_version }}-server.zip /tmp
 RUN mkdir -p ${APP_ROOT} && \
     unzip /tmp/{{ product }}-{{ xl_version }}-server.zip -d ${APP_ROOT} && \
-    mv ${APP_ROOT}/{{ product }}-{{ xl_version }}-server ${APP_HOME}
+    mv ${APP_ROOT}/{{ product }}-{{ xl_version }}-server ${APP_HOME} && \
+{%- if skip_vulnerable_libs %}
+    rm ${APP_HOME}/lib/derby*.jar && \
+    rm -fr ${APP_HOME}/derbyns/ && \
+{%- endif %}
+    true
 
 # Add bin/run-in-container.sh
 COPY resources/bin/run-in-container.sh ${APP_HOME}/bin/
@@ -17,10 +22,9 @@ COPY resources/jmx-exporter/jmx_prometheus_javaagent.jar ${APP_HOME}/lib/
 # Add (and run) Database driver download script
 COPY resources/bin/db-drivers.sh /tmp
 RUN chmod ugo+x /tmp/db-drivers.sh && \
-    /bin/sh /tmp/db-drivers.sh
-
-# Modify bin/run.sh so that java becomes a child process of dumb-init
-RUN sed -i 's/^\($JAVACMD\)/exec \1/' ${APP_HOME}/bin/run.sh
+    /bin/sh /tmp/db-drivers.sh && \
+    # Modify bin/run.sh so that java becomes a child process of dumb-init
+    sed -i 's/^\($JAVACMD\)/exec \1/' ${APP_HOME}/bin/run.sh
 
 {% if commons.central_configuration_enabled %}
 
@@ -55,23 +59,26 @@ COPY resources/modify-wrapper-linux-conf.gawk /tmp
 RUN chmod +x /tmp/modify-wrapper-linux-conf.gawk && \
     /tmp/modify-wrapper-linux-conf.gawk ${APP_HOME}/default-conf/{{ wrapper_conf }} > /tmp/{{ wrapper_conf}} && \
     mv /tmp/{{ wrapper_conf }} ${APP_HOME}/default-conf/{{ wrapper_conf }} && \
-    rm /tmp/modify-wrapper-linux-conf.gawk
-
-# Create node-specific conf directory and add template for node-specific {{ product }}.conf file
-# The node-specific {{ product }}.conf file provides HOSTNAME, HOSTNAME_SUFFIX & XL_NODE_NAME to the instance, which are then merged with the
-# ${APP_HOME}/conf/{{ product }}.conf file by the xl-platform
-RUN mkdir ${APP_HOME}/node-conf
+    rm /tmp/modify-wrapper-linux-conf.gawk && \
+    # Create node-specific conf directory and add template for node-specific {{ product }}.conf file
+    # The node-specific {{ product }}.conf file provides HOSTNAME, HOSTNAME_SUFFIX & XL_NODE_NAME to the instance, which are then merged with the
+    # ${APP_HOME}/conf/{{ product }}.conf file by the xl-platform
+    mkdir ${APP_HOME}/node-conf
 COPY resources/node-conf ${APP_HOME}/node-conf
 
 # Move plugins directory to default-plugins, so that when no external plugins are loaded we can use the default
 RUN mv ${APP_HOME}/plugins ${APP_HOME}/default-plugins && \
-    mkdir ${APP_HOME}/plugins
-
-# Create empty 'repository', 'work', 'export', 'archive' and 'reports' directory
-RUN mkdir ${APP_HOME}/repository ${APP_HOME}/export ${APP_HOME}/archive ${APP_HOME}/work ${APP_HOME}/reports
+    mkdir ${APP_HOME}/plugins && \
+    # Create empty 'repository', 'work', 'export', 'archive' and 'reports' directory
+    mkdir ${APP_HOME}/repository ${APP_HOME}/export ${APP_HOME}/archive ${APP_HOME}/work ${APP_HOME}/reports
 
 # Set permissions
-RUN addgroup -S -g 10001 xebialabs
-RUN chgrp -R 10001 ${APP_ROOT} && \
+{%- if target_os == "redhat" %}
+RUN groupadd -r -g 10001 xebialabs && \
+{%- else %}
+RUN addgroup -S -g 10001 xebialabs && \
+{%- endif %}
+    chown -R 10001:10001 ${APP_ROOT} && \
     chmod -R g=u ${APP_ROOT} && \
+    chmod u+x ${APP_HOME}/bin/*.sh && \
     chmod g+x ${APP_HOME}/bin/*.sh

--- a/templates/dockerfiles/metadata.j2
+++ b/templates/dockerfiles/metadata.j2
@@ -1,10 +1,8 @@
-MAINTAINER XebiaLabs Development <docker@xebialabs.com>
 
 LABEL name="xebialabs/{{ product }}" \
-      maintainer="docker@xebialabs.com" \
-      vendor="XebiaLabs" \
+      vendor="Digital.ai" \
       version="{{ image_version }}" \
       release="1" \
       summary="{{ product_name }}" \
-      description="Enterprise-scale Application Release Automation for any environment" \
-      url="https://www.xebialabs.com/{{ product }}"
+      description="{{ product_description }}" \
+      url="{{ product_info_url }}"

--- a/templates/dockerfiles/redhat/Dockerfile.j2
+++ b/templates/dockerfiles/redhat/Dockerfile.j2
@@ -1,0 +1,51 @@
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest as installer
+
+# Install dependencies
+USER root
+RUN microdnf update -y && rm -rf /var/cache/yum && \
+   INSTALL_PKGS="curl hostname shadow-utils which unzip gawk" && \
+   microdnf install --nodocs ${INSTALL_PKGS} && \
+   ### Install JQ
+   JQ_LOCATION="/usr/bin/jq" && \
+   curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -L > $JQ_LOCATION && chmod +x $JQ_LOCATION && \
+   microdnf clean all
+
+{% if 'deploy-task-engine' in product %}
+    {% include './deploy-task-engine/install.j2' %}
+{% elif 'central-config' in product %}
+    {% include './central-configuration/install.j2' %}
+{% else %}
+    {% include 'install.j2' %}
+{% endif %}
+
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
+
+{% include 'metadata.j2' %}
+
+### add licenses to this directory
+COPY resources/licenses /licenses
+
+{% if 'deploy-task-engine' in product %}
+    {% include './deploy-task-engine/variables.j2' %}
+{% else %}
+    {% include 'variables.j2' %}
+{% endif %}
+
+# Copy installed {{ product_name }}
+COPY --from=installer ${APP_ROOT} ${APP_ROOT}
+
+ENV OS=redhat
+USER root
+
+RUN microdnf update -y && rm -rf /var/cache/yum && \
+   INSTALL_PKGS="curl hostname shadow-utils which unzip nc" && \
+   microdnf install --nodocs ${INSTALL_PKGS} && \
+   JQ_LOCATION="/usr/bin/jq" && \
+   curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -L > $JQ_LOCATION && chmod +x $JQ_LOCATION && \
+   microdnf clean all
+
+{% if 'deploy' in product %}
+    {% include 'terraform.j2' %}
+{% endif %}
+
+{% include 'runtime.j2' %}

--- a/templates/dockerfiles/runtime.j2
+++ b/templates/dockerfiles/runtime.j2
@@ -1,17 +1,12 @@
+
 # Set ttl for DNS cache
 RUN echo $'\n#\n# Set TTL for DNS cache.\nnetworkaddress.cache.ttl=30' >> $(readlink -f `which java` | sed -e 's:/jre/bin/java::' -e 's:/bin/java::')/conf/security/java.security
 
 COPY resources/amd64/tini ${APP_ROOT}
-RUN chmod ugo+x ${APP_ROOT}/tini
-
-# Don't run as root
-RUN groupadd -r -g 10001 xebialabs
-RUN useradd -r -M -u 10001 -g 0 -G xebialabs xebialabs
-
-# Set permissions
-RUN chown -R 10001 ${APP_ROOT} && \
-    chmod u+x ${APP_HOME}/bin/*.sh &&\
-    chmod -R g=u ${APP_ROOT}
+# Don't run as root and set permissions
+RUN chmod ugo+x ${APP_ROOT}/tini && \
+    groupadd -f -r -g 10001 xebialabs && \
+    useradd -r -M -u 10001 -g 0 -G xebialabs xebialabs
 
 WORKDIR ${APP_HOME}
 

--- a/templates/dockerfiles/variables.j2
+++ b/templates/dockerfiles/variables.j2
@@ -1,3 +1,4 @@
 # Set root folders
-ENV USER_UID=10001 APP_ROOT=/opt/xebialabs
-ENV APP_HOME=${APP_ROOT}/{{ product }}-server
+ENV USER_UID=10001 \
+    APP_ROOT=/opt/xebialabs \
+    APP_HOME=/opt/xebialabs/{{ product }}-server

--- a/templates/resources/common/licenses/license.txt
+++ b/templates/resources/common/licenses/license.txt
@@ -1,0 +1,83 @@
+
+EULA Artifacts Digital.ai, Version 1.0
+
+1. Other Agreement.
+
+  This EULA applies to Your Use of the Artifacts.
+  However, it's possible that You have entered into a separate written
+  agreement with Us in respect of the Artifacts which is intended to
+  supersede this EULA. In that case, such separate written agreement will
+  govern Your Use of the Artifacts.
+
+2. Definitions.
+
+  "License" means the license defined in article 3 below. "Artifacts" means
+  the object code versions of software made available by Us under this EULA.
+  "Use" means use of the Artifacts by You for Your own internal business
+  purposes only. "We", "Our" and "Us" means Digital.ai Inc., a corporation
+  with its principal place of business at 555 Fayetteville St, Raleigh, NC 
+  27601, United States of America. "You" and "Your" means
+  you, the person or legal entity who is granted a License to Use the
+  Artifacts under these terms and conditions.
+
+3. License.
+
+  We grant You free of charge a non-exclusive, non-transferrable, non-sub
+  licensable right to Use the Artifacts within your legal entity and under
+  these terms and conditions. The License does not include the right to
+  copy, reproduce, resale, distribute, lease, rent, sublicense or otherwise
+  make the Artifacts available to any third party without Our prior written
+  approval. The License does not include the right to reverse-engineer,
+  decompile, disassemble or otherwise attempt to determine source code or
+  protocols from the Artifacts. You shall not create or attempt to create
+  any derivative works from the Artifacts, or use the Artifacts in any way
+  to create products and/or services that compete with Our products and/or
+  services. We retain all rights not expressly granted to You under these
+  terms and conditions.
+
+4. Warranty and Liability.
+
+  We warrant that We are entitled to license the Artifacts to You. We do
+  not warrant that operation of the Artifacts shall be uninterrupted or
+  "bug" free. EXCEPT FOR THE FOREGOING WARRANTIES, THE ARTIFACTS ARE
+  PROVIDED WITHOUT ANY IMPLIED OR OTHER EXPRESS WARRANTIES, INCLUDING BUT
+  NOT LIMITED TO WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE AND
+  MERCHANTABILITY. Our liability for damages concerning the performance or
+  non-performance by Us in relation to these terms and conditions, and
+  regardless of whether the claim for such damages is based in contract,
+  tort, strict liability, or otherwise, is limited to an amount of $ 100
+  USD. In no event shall We be liable for any indirect, incidental,
+  special, punitive or consequential damages, lost data, or lost profits,
+  even if We has been advised to the possibility of such damages.
+
+5. Intellectual Property.
+
+  Title, ownership rights and all intellectual property rights in and to the
+  Artifacts shall remain the sole and exclusive property and that of Us and
+  Our licensors. If a third party claims that Your use of the Artifacts
+  infringes any patent, copyright, trademark or trade secret, You shall
+  promptly notify Us thereof. We shall have no liability for any third
+  party claim of infringement based upon Your use of the Artifacts under
+  these terms and conditions. You shall not remove any of the logos,
+  product names or trademarks applied in or on the Artifacts and
+  Documentation. You shall have no right to use any logos, product names or
+  trademarks without the prior written consent of Us or Our licensors.
+
+6. Miscellaneous.
+
+  You shall comply with any export control laws. None of these terms and
+  conditions are enforceable by any person or entity who is not a party to
+  it. These terms and conditions constitute the entire agreement between Us
+  and You regarding the Artifacts and Documentation and no amendment to
+  these terms and conditions will be effective unless in writing and signed
+  by both parties hereto. The provisions of these terms and conditions are
+  to be considered separately, and if any provision hereof should be found
+  by any court or competent jurisdiction to be invalid or unenforceable,
+  these terms and conditions will be deemed to have effect as if such
+  invalid or unenforceable provision were severed from these terms and
+  conditions. These terms and conditions are governed by the laws of the
+  North Carolina, excluding its conflict of law rules and the
+  UN Convention for the International Sale of Goods (CISG). Any dispute
+  regarding these terms and conditions, or disputes arising from these terms
+  and conditions, shall be subject to the exclusive jurisdiction of the
+  court of the Commonwealth of Massachusetts.


### PR DESCRIPTION
What was changed:
- added redhat image build with UBI8 base image
- added licence: templates/resources/common/licenses/license.txt
- reduced number of image layers 
- changes in image LABELs, removed deprecated MAINTAINER
- add target_os in the applejack context (there are some differences during build in the OS commands)
- add skip_vulnerable_libs  in the applejack context (to skip derby), it is not passing Redhat scans, it is enabled by using --skip_vulnerable_libs  during render
- improved efficiency score  for around 20%-30% of the images (for centos is now around 83% or more because OS upgrades during build, for others is around 95%)

## Definition of Done

**General**
 - [x] Branch is up-to-date with master
 - [x] Code is reviewed and tested by someone in the Kube team
 - [x] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

