### PR TITLE
D-34407 type-default.properties are not synced from the central-conf

### DIFF
--- a/templates/resources/includes/central-configuration-run-script.j2
+++ b/templates/resources/includes/central-configuration-run-script.j2
@@ -15,7 +15,7 @@ if [ ! -f "${APP_HOME}/conf/{{ boot_conf }}" ]; then
   echo "Done"
 fi
 
-# copy default configurations
+# copy default configurations default-conf
 echo "... Copying default configuration from ${APP_HOME}/default-conf"
 
 for f in *; do
@@ -29,5 +29,23 @@ for f in *; do
     cp -R $f ${APP_HOME}/conf/
   fi
 done
+
+# copy default configurations central-conf
+echo "... Copying default configuration from ${APP_HOME}/central-conf"
+
+cd ${APP_HOME}/central-conf
+
+for f in *; do
+  if [[ $f == *.template ]]; then
+    continue
+  fi
+  if [ -f ${APP_HOME}/centralConfiguration/$f ]; then
+    echo "... Not copying $f because it already exists in the centralConfiguration directory"
+  else
+    echo "... Copying $f to the centralConfiguration directory"
+    cp -R $f ${APP_HOME}/centralConfiguration/
+  fi
+done
+
 cd ${APP_HOME}
 echo "Done copying default configurations"


### PR DESCRIPTION
## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

