### PR TITLE
D-35538 [24.1] Fix jgit warning

### DIFF
--- a/applejack/conf/products/xl-release.yml
+++ b/applejack/conf/products/xl-release.yml
@@ -96,3 +96,5 @@ context:
     value: "true"
   - key: LOGBACK_SCAN_PERIOD
     value: "30seconds"
+  - key: XDG_CONFIG_HOME
+    value: "/tmp/jgit"

--- a/documentation/docs/manual/environment-variables.md
+++ b/documentation/docs/manual/environment-variables.md
@@ -191,6 +191,11 @@ sidebar_position: 1
 - default value: none
 - example: "MQ_P@ssw0rd01"
 
+##### `XDG_CONFIG_HOME`
+- Config home directory required by jgit library.
+- possible values: "container-directory-with-write-permissions-for-jgit-lib"
+- default value: "/tmp/jgit"
+
 ### Specific for XLDeploy docker images:-
 
 ##### `APP_PORT`


### PR DESCRIPTION
* D-35538 Fix jgit warning by setting specific config home environment variable

* D-35538 Updated environment variable documentation

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

