### PR TITLE
S-116709 [25.1] Add JVM networkaddress.cache.ttl to deploy task engine

### DIFF
--- a/applejack/conf/products/deploy-task-engine.yml
+++ b/applejack/conf/products/deploy-task-engine.yml
@@ -72,3 +72,5 @@ context:
       value: "true"
     - key: LOGBACK_SCAN_PERIOD
       value: "30seconds"
+    - key: NETWORK_ADDRESS_CACHE_TTL
+      value: "30"

--- a/templates/resources/includes/deploy-task-engine-run-script.j2
+++ b/templates/resources/includes/deploy-task-engine-run-script.j2
@@ -68,6 +68,17 @@ if [[ -z "$APP_CONTEXT_ROOT" ]]; then
   APP_CONTEXT_ROOT="/"
 fi
 
+# Set up new installation for security.properties
+if [ ! -f "${APP_HOME}/conf/security.properties" ]; then
+  echo "No ${APP_HOME}/conf/security.properties file detected:"
+
+  echo "... Generating {{ boot_conf }}"
+
+  sed -e "s#\${NETWORK_ADDRESS_CACHE_TTL}#${NETWORK_ADDRESS_CACHE_TTL}#g" \
+      ${APP_HOME}/default-conf/security.properties.template > ${APP_HOME}/conf/security.properties
+  echo "Done"
+fi
+
 # Set up new installation
 if [ ! -f "${APP_HOME}/conf/{{ boot_conf }}" ]; then
   echo "No ${APP_HOME}/conf/{{ boot_conf }} file detected:"


### PR DESCRIPTION
## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

