### PR TITLE
S-131635 Fix errors with removal of bundled db jars if not available

### DIFF
--- a/templates/dockerfiles/install.j2
+++ b/templates/dockerfiles/install.j2
@@ -17,11 +17,9 @@ RUN mkdir -p ${APP_HOME}/driver/jdbc && \
 
 {%- if is_slim %}
 # Remove bundled drivers if slim
-RUN rm ${APP_HOME}/lib/derby*.jar && \
+RUN rm -f ${APP_HOME}/lib/derby*.jar && \
     rm -fr ${APP_HOME}/derbyns/ && \
-    {% if 'xl-release' in product -%}
-    rm ${APP_HOME}/lib/h2*.jar && \
-    {% endif -%}
+    rm -f ${APP_HOME}/lib/h2*.jar && \
     true
 {%- endif %}
 


### PR DESCRIPTION
After S-130600 - Drop Derby support
Building images fail due to derby jars not present in server package.
With this change, the non existing file should not fail. 

## Definition of Done

**General**
 - [ ] Branch is up-to-date with master
 - [ ] Code is reviewed and tested by someone in the Kube team
 - [ ] If there are user facing changes (new env variables for example) update the docs and make sure to notify the docs team to update official documentation 

